### PR TITLE
margin bottom doesn't work in Safari

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -74,7 +74,7 @@ form.index {
 }
 
 body {
-	margin-bottom: 50px;
+	padding-bottom: 50px;
 }
 
 body p {


### PR DESCRIPTION
Safariではmargin-bottomで指定した余白が効いていないようです。その結果、iPhone5sではSAVEボタンがfollowボタンに隠れてしまって押せなくなっていました。
padding-bottomであれば、Chrome, Safariともに余白が有効になりました。