### PR TITLE
add retry_writes option to mongoid for error of heroku

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -2,6 +2,8 @@ production:
   clients:
     default:
       uri: <%= ENV['MONGODB_URI'] || ENV['MONGOLAB_URI'] %>
+      options:
+        retry_writes: false
 development:
   clients:
     default:


### PR DESCRIPTION
HerokuのMongoDBで以下のエラーが出るようになったので`config/mongoid.yaml`に`retry_writes`オプションを追加した。

> Mongo::Error::OperationFailure - Mongo::Error::OperationFailure: Transaction numbers are only allowed on storage engines that support document-level locking (20) (on ds143245-a.mlab.com:43245, attempt 1) This MongoDB deployment does not support retryable writes. Please add retryWrites=false to your connection string or use the retry_writes: false Ruby client option: