### PR TITLE
Ignore services

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -15,6 +15,9 @@ module TakuhaiTracker
 		configure do
 			Mongoid::load!('config/mongoid.yml')
 			Mongo::Logger.level = Logger::FATAL
+			(ENV['IGNORE_SERVICES'] || '').split(/,/).each do |service|
+				TakuhaiStatus.ignore_service(service)
+			end
 		end
 
 		def pushbullet_valid?(token)

--- a/app.rb
+++ b/app.rb
@@ -16,7 +16,9 @@ module TakuhaiTracker
 			Mongoid::load!('config/mongoid.yml')
 			Mongo::Logger.level = Logger::FATAL
 			(ENV['IGNORE_SERVICES'] || '').split(/,/).each do |service|
-				TakuhaiStatus.ignore_service(service)
+				unless TakuhaiStatus.ignore_service(service.to_sym)
+					logger.warn "invalid ignore service name: #{service}"
+				end
 			end
 		end
 

--- a/tasks/worker.rb
+++ b/tasks/worker.rb
@@ -21,9 +21,6 @@ module TakuhaiTracker::Worker
 		'Sagawa'         => '佐川急便',
 		'TMGCargo'       => 'TMG'
 	}.freeze
-	(ENV['IGNORE_SERVICES'] || '').split(/,/).each do |service|
-		TakuhaiStatus.ignore_service(service)
-	end
 
 	class ItemNotFound < StandardError; end
 	class ItemExpired  < StandardError; end
@@ -200,6 +197,12 @@ task :worker do
 	logger.debug "running under dry run mode" if TakuhaiTracker::Worker.dry_run?
 
 	Mongoid::load!('config/mongoid.yml')
+
+	(ENV['IGNORE_SERVICES'] || '').split(/,/).each do |service|
+		unless TakuhaiStatus.ignore_service(service.to_sym)
+			logger.warn "invalid ignore service name: #{service}"
+		end
+	end
 
 	retry_count = 0
 	begin

--- a/tasks/worker.rb
+++ b/tasks/worker.rb
@@ -21,7 +21,6 @@ module TakuhaiTracker::Worker
 		'Sagawa'         => '佐川急便',
 		'TMGCargo'       => 'TMG'
 	}.freeze
-
 	class ItemNotFound < StandardError; end
 	class ItemExpired  < StandardError; end
 	class RetryNext  < StandardError; end

--- a/tasks/worker.rb
+++ b/tasks/worker.rb
@@ -21,6 +21,10 @@ module TakuhaiTracker::Worker
 		'Sagawa'         => '佐川急便',
 		'TMGCargo'       => 'TMG'
 	}.freeze
+	(ENV['IGNORE_SERVICES'] || '').split(/,/).each do |service|
+		TakuhaiStatus.ignore_service(service)
+	end
+
 	class ItemNotFound < StandardError; end
 	class ItemExpired  < StandardError; end
 	class RetryNext  < StandardError; end


### PR DESCRIPTION
環境変数`IGNORE_SERVICES`にカンマ区切りでスキャン対象にしないサービス名を指定する。

例: `IGNORE_SERVICES=USPS,TmgCargo`

Web、Workerどちらでも同じ。