### PR TITLE
delete ignore_service in woeker

### DIFF
--- a/tasks/worker.rb
+++ b/tasks/worker.rb
@@ -197,12 +197,6 @@ task :worker do
 
 	Mongoid::load!('config/mongoid.yml')
 
-	(ENV['IGNORE_SERVICES'] || '').split(/,/).each do |service|
-		unless TakuhaiStatus.ignore_service(service.to_sym)
-			logger.warn "invalid ignore service name: #{service}"
-		end
-	end
-
 	retry_count = 0
 	begin
 		TakuhaiTracker::Item.all.each do |item|


### PR DESCRIPTION
ignore_service が app.rb と worker.rb で二重に呼ばれているので、worker で毎回 warning が出ていた。worker 側を削除。